### PR TITLE
[fix] The directory is not recognized when it is in a soft link

### DIFF
--- a/tools/goctl/util/ctx/gomod.go
+++ b/tools/goctl/util/ctx/gomod.go
@@ -81,7 +81,12 @@ func getRealModule(workDir string, execRun execx.RunFunc) (*Module, error) {
 		return nil, err
 	}
 	for _, m := range modules {
-		if strings.HasPrefix(workDir, m.Dir) {
+		mRealDir, _ := pathx.ReadLink(m.Dir)
+		if err != nil {
+			continue
+		}
+
+		if strings.HasPrefix(workDir, mRealDir) {
 			return &m, nil
 		}
 	}


### PR DESCRIPTION
if my workspace dir is soft link, couldn't match go.mod dir `go list -json -m`

e.g. 

workspace: `$HOME/www` real dir is `/usr/local/www`
workDir:  `$HOME/www/demo1` real dir is `/usr/local/www/demo1`
go.mod Dir: `$HOME/www/demo1` but not real dir

```
strings.HasPrefix(workDir, m.Dir) // always return false
```
